### PR TITLE
Add resources, sources, and references during create component flow

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "trailingComma": "es5",
+  "semi": true,
+  "singleQuote": false,
+  "printWidth": 100,
+  "tabWidth": 2
+}

--- a/media/addComponent/view.js
+++ b/media/addComponent/view.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 const vscode = acquireVsCodeApi();
 
@@ -10,28 +10,28 @@ const vscode = acquireVsCodeApi();
  * }}
  */
 const webviewTempState = {
-	repository: '',
-	componentName: '',
+  repository: "",
+  componentName: "",
 };
 
 // Generic cluster input ids
-const repositoryId = 'repository';
-const componentId = 'component';
+const repositoryId = "repository";
+const componentId = "component";
 
 // Inputs
 const $repository = /** @type HTMLInputElement */ (document.getElementById(repositoryId));
 const $component = /** @type HTMLInputElement */ (document.getElementById(componentId));
-const $submitButton = /** @type HTMLButtonElement */ (document.getElementById('add-component'));
+const $submitButton = /** @type HTMLButtonElement */ (document.getElementById("add-component"));
 
-$submitButton.addEventListener('click', () => {
-	postVSCodeMessage({
-		type: 'addComponent',
-		value: {
-			// @ts-ignore
-			repositoryURL: getInputValue(repositoryId),
-			componentName: getInputValue(componentId),
-		},
-	});
+$submitButton.addEventListener("click", () => {
+  postVSCodeMessage({
+    type: "addComponent",
+    value: {
+      // @ts-ignore
+      repositoryURL: getInputValue(repositoryId),
+      componentName: getInputValue(componentId),
+    },
+  });
 });
 
 // ────────────────────────────────────────────────────────────
@@ -39,20 +39,20 @@ $submitButton.addEventListener('click', () => {
  * @param message {import('../../src/webviews/addComponent').MessageFromWebview}
  */
 function postVSCodeMessage(message) {
-	vscode.postMessage(message);
+  vscode.postMessage(message);
 }
 
 /**
  * @param {string} text
  */
 function showNotification(text, isModal = false) {
-	postVSCodeMessage({
-		type: 'showNotification',
-		value: {
-			text,
-			isModal,
-		},
-	});
+  postVSCodeMessage({
+    type: "showNotification",
+    value: {
+      text,
+      isModal,
+    },
+  });
 }
 
 /**
@@ -61,21 +61,21 @@ function showNotification(text, isModal = false) {
  * @returns {string} input value or empty string
  */
 function getInputValue(inputId) {
-	return /** @type null | HTMLInputElement */ (document.getElementById(inputId))?.value || '';
+  return /** @type null | HTMLInputElement */ (document.getElementById(inputId))?.value || "";
 }
 
-window.addEventListener('message', event => {
-	/** @type {import('../../src/webviews/addComponent').MessageToWebview} */
-	const message = event.data;
+window.addEventListener("message", (event) => {
+  /** @type {import('../../src/webviews/addComponent').MessageToWebview} */
+  const message = event.data;
 
-	switch (message.type) {
-		case 'updateWebviewContent': {
-			break;
-		}
-	}
+  switch (message.type) {
+    case "updateWebviewContent": {
+      break;
+    }
+  }
 });
 
 postVSCodeMessage({
-	type: 'webviewLoaded',
-	value: true,
+  type: "webviewLoaded",
+  value: true,
 });

--- a/media/createComponent/view.css
+++ b/media/createComponent/view.css
@@ -67,6 +67,10 @@ span {
 	float: right;
 }
 
+.submit-button:disabled, .submit-button:hover:disabled {
+	background-color: var(--vscode-disabledForeground);
+}
+
 .generic-button {
 	width: fit-content;
 	padding: 6px 12px;
@@ -94,4 +98,20 @@ span {
 .vscode-light .cli-argument {
 	background-color: rgba(0, 0, 0, 0.02);
 	border-color: rgba(0, 0, 0, 0.15);
+}
+
+.addon-form {
+	border: 1px solid var(--vscode-focusBorder);
+	padding: 0.8em;
+	margin: 1em 0;
+}
+
+.invalid {
+	border-color: rgb(238, 62, 62) !important;
+}
+
+.validation-error {
+	color: rgb(238, 62, 62);
+	font-size: 12px;
+	margin-top: 1px;
 }

--- a/media/createComponent/view.css
+++ b/media/createComponent/view.css
@@ -34,6 +34,17 @@ input[type="checkbox"] + label {
 	vertical-align: middle;
 	display: inline-block;
 }
+select {
+	padding: 6px;
+	border: 1px solid var(--vscode-input-border);
+	background-color: var(--vscode-input-background);
+	color: var(--vscode-input-foreground);
+}
+
+span {
+	display: block;
+	overflow: hidden;
+}
 
 .app {
 	max-width: max(50%, 800px);
@@ -43,7 +54,7 @@ input[type="checkbox"] + label {
 
 .header-label {
 	display: block;
-	margin-bottom: 0.2em;
+	margin-bottom: 0.4em;
 	margin-top: 0.6em;
 }
 
@@ -54,6 +65,23 @@ input[type="checkbox"] + label {
 	text-overflow: ellipsis;
 	margin: 10px 0;
 	float: right;
+}
+
+.generic-button {
+	width: fit-content;
+	padding: 6px 12px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	margin: 10px 0;
+	display: block;
+}
+
+.filepicker-button {
+	width: fit-content;
+	padding: 6px 12px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	float: left;
 }
 
 .cli-argument {

--- a/media/createComponent/view.html
+++ b/media/createComponent/view.html
@@ -6,6 +6,9 @@
 		<label class="header-label" for="componentName">Component Name</label><input type="text" id="componentName" placeholder="<namespace>/<name> - e.g. ocm.software/podinfo">
 	</div>
 	<div>
+		<label class="header-label" for="path">Path</label><input type="text" id="path" placeholder="Relative path within workspace - e.g. components/my-component">
+	</div>
+	<div>
 		<label class="header-label" for="version">Version</label><input type="text" id="version" placeholder="SemVer - e.g. 1.0.1">
 	</div>
 	<div>

--- a/media/createComponent/view.html
+++ b/media/createComponent/view.html
@@ -18,6 +18,8 @@
 		</select>
 	</div>
 	<button type="button" id="add-resource" class="generic-button">Add Resource</button>
+	<button type="button" id="add-source" class="generic-button">Add Source</button>
+	<button type="button" id="add-reference" class="generic-button">Add Reference</button>
 </div>
 
 <button type="button" id="create-component" class="submit-button">Create</button>

--- a/media/createComponent/view.html
+++ b/media/createComponent/view.html
@@ -17,6 +17,7 @@
 			<option value="v2">v2</option>
 		</select>
 	</div>
+	<button type="button" id="add-resource" class="generic-button">Add Resource</button>
 </div>
 
 <button type="button" id="create-component" class="submit-button">Create</button>

--- a/media/createComponent/view.js
+++ b/media/createComponent/view.js
@@ -165,14 +165,18 @@ $submitBtn.addEventListener("click", () => {
         continue;
       }
 
-      component.value["sources"].push({
-        name: getInputValue(`sourceName-${i}`),
-        version: getInputValue(`sourceVersion-${i}`),
-        // @ts-ignore
-        accessType: getInputValue(`sourceAccessType-${i}`),
-        repoUrl: getInputValue(`sourceRepoUrl-${i}`),
-        commit: getInputValue(`sourceCommit-${i}`),
-      });
+      switch (getInputValue(`sourceAccessType-${i}`)) {
+        case "gihHub": {
+          component.value["sources"].push({
+            name: getInputValue(`sourceName-${i}`),
+            version: getInputValue(`sourceVersion-${i}`),
+            // @ts-ignore
+            accessType: getInputValue(`sourceAccessType-${i}`),
+            repoUrl: getInputValue(`sourceRepoUrl-${i}`),
+            commit: getInputValue(`sourceCommit-${i}`),
+          });
+        }
+      }
     }
   }
 
@@ -315,9 +319,30 @@ function addSourceForm(i) {
   <h3>Add Source</h3>
   <div>
     <label class="header-label" for="sourceAccessType-${i}">Source Type</label><select name="sourceAccessType-${i}" id="sourceAccessType-${i}">
+      <option disabled selected value> -- select an option -- </option>
       <option value="gitHub">GitHub</option>
 		</select>
   </div>
+  `;
+
+  $addSourceButton.insertAdjacentElement("beforebegin", div);
+  document.getElementById(`sourceAccessType-${i}`)?.addEventListener("change", (e) => {
+    const sourceType = /** @type HTMLSelectElement */ (e.target).value;
+    switch (sourceType) {
+      case "gitHub": {
+        addGitHubSourceForm(i);
+        break;
+      }
+    }
+  });
+}
+
+/**
+ *
+ * @param {number} i
+ */
+function addGitHubSourceForm(i) {
+  const html = `
   <div>
     <label class="header-label" for="sourceName-${i}">Source Name</label><input type="text" name="sourceName-${i}" id="sourceName-${i}" />
   </div>
@@ -332,7 +357,7 @@ function addSourceForm(i) {
   </div>
   `;
 
-  $addSourceButton.insertAdjacentElement("beforebegin", div);
+  document.getElementById(`source-form-${i}`)?.insertAdjacentHTML("beforeend", html);
 }
 
 /**

--- a/media/createComponent/view.js
+++ b/media/createComponent/view.js
@@ -166,7 +166,7 @@ $submitBtn.addEventListener("click", () => {
       }
 
       switch (getInputValue(`sourceAccessType-${i}`)) {
-        case "gihHub": {
+        case "gitHub": {
           component.value["sources"].push({
             name: getInputValue(`sourceName-${i}`),
             version: getInputValue(`sourceVersion-${i}`),

--- a/media/createComponent/view.js
+++ b/media/createComponent/view.js
@@ -62,6 +62,30 @@ $addResourceButton.addEventListener("click", () => {
 });
 
 $submitBtn.addEventListener("click", () => {
+  const inputs = /** @type NodeListOf<HTMLInputElement> */ (
+    document.querySelectorAll("#generic-form input[type=text]")
+  );
+  if (inputs.length !== 0) {
+    let invalidFields = 0;
+    inputs.forEach((input) => {
+      if (!input.value.trim()) {
+        invalidFields++;
+        if (input.classList.contains("invalid")) {
+          return;
+        }
+        input.classList.add("invalid");
+        input.insertAdjacentHTML(
+          "afterend",
+          `<span class="validation-error">This field is required.</span>`
+        );
+        updateInvalidField(input);
+      }
+    });
+    if (invalidFields > 0) {
+      return;
+    }
+  }
+
   /** @type {import('../../src/webviews/createComponent').CreateComponentMessage} */
   const component = {
     type: "createComponent",
@@ -244,6 +268,19 @@ function addOciImageResourceForm(i) {
   `;
 
   document.getElementById(`resource-form-${i}`)?.insertAdjacentHTML("beforeend", html);
+}
+
+/**
+ *
+ * @param {Element} field
+ */
+function updateInvalidField(field) {
+  field?.addEventListener("input", (e) => {
+    if (field?.classList.contains("invalid")) {
+      field.classList.remove("invalid");
+      field.nextElementSibling?.remove();
+    }
+  });
 }
 
 /**

--- a/media/createComponent/view.js
+++ b/media/createComponent/view.js
@@ -2,37 +2,68 @@
 
 const vscode = acquireVsCodeApi();
 
-/**
- *
- * @type { {
- * componentName: string;
- * version: string;
- * provider: string;
- * scheme: string;
- * }}
- */
-const webviewTempState = {
-  componentName: "",
-  version: "",
-  provider: "",
-  scheme: "",
-};
+// /**
+//  * @type {{
+//  * componentName: string;
+//  * version: string;
+//  * provider: string;
+//  * scheme: string;
+//  * resources: [];
+//  * }}
+//  */
+// const webviewTempState = {
+//   componentName: "",
+//   version: "",
+//   provider: "",
+//   scheme: "",
+// };
 
-// Generic cluster input ids
+let resourceCount = 0;
+
+// Generic component input ids
 const componentName = "componentName";
 const version = "version";
 const provider = "provider";
 const scheme = "scheme";
 
-// Inputs
-const $component = /** @type HTMLInputElement */ (document.getElementById(componentName));
-const $version = /** @type HTMLInputElement */ (document.getElementById(version));
-const $provider = /** @type HTMLInputElement */ (document.getElementById(provider));
-const $scheme = /** @type HTMLInputElement */ (document.getElementById(scheme));
-const $submitButton = /** @type HTMLButtonElement */ (document.getElementById("create-component"));
+const $addResourceButton = /** @type HTMLButtonElement */ (document.getElementById("add-resource"));
+const $submitBtn = /** @type HTMLButtonElement */ (document.getElementById("create-component"));
 
-$submitButton.addEventListener("click", () => {
-  postVSCodeMessage({
+$addResourceButton.addEventListener("click", () => {
+  addResourceForm(resourceCount);
+
+  document.getElementById(`resourceInputType-${resourceCount}`)?.addEventListener("change", (e) => {
+    // @ts-ignore
+    const resourceType = e.target?.value;
+    // @ts-ignore
+    const resourceNumber = e.target?.parentNode.parentNode.dataset.resourceCounter;
+
+    if (document.getElementById(`resource-fields-${resourceNumber}`)) {
+      document.getElementById(`resource-fields-${resourceNumber}`)?.remove();
+    }
+
+    switch (resourceType) {
+      case "file": {
+        addFileResourceForm(resourceNumber);
+        break;
+      }
+      case "directory": {
+        addDirectoryResourceForm(resourceNumber);
+        break;
+      }
+      case "ociImage": {
+        addOciImageResourceForm(resourceNumber);
+        break;
+      }
+    }
+  });
+
+  resourceCount++;
+});
+
+$submitBtn.addEventListener("click", () => {
+  /** @type {import('../../src/webviews/createComponent').CreateComponentMessage} */
+  const component = {
     type: "createComponent",
     value: {
       // @ts-ignore
@@ -40,9 +71,193 @@ $submitButton.addEventListener("click", () => {
       version: getInputValue(version),
       provider: getInputValue(provider),
       scheme: getInputValue(scheme),
+      resources: [],
     },
-  });
+  };
+
+  if (resourceCount > 0) {
+    component.value["resources"] = [];
+    for (let i = 0; i < resourceCount; i++) {
+      if (!document.getElementById(`resource-form-${i}`)) {
+        console.log("not found");
+        continue;
+      }
+
+      switch (getInputValue(`resourceInputType-${i}`)) {
+        case "file": {
+          component.value["resources"].push({
+            // @ts-ignore
+            inputType: getInputValue(`resourceInputType-${i}`),
+            name: getInputValue(`resourceName-${i}`),
+            type: getInputValue(`resourceType-${i}`),
+            mediaType: getInputValue(`resourceMediaType-${i}`),
+            path: getInputValue(`resourcePath-${i}`),
+            // @ts-ignore
+            compress: getInputValue(`compressResource-${i}`),
+          });
+          break;
+        }
+        case "directory": {
+          component.value["resources"].push({
+            // @ts-ignore
+            inputType: getInputValue(`resourceInputType-${i}`),
+            name: getInputValue(`resourceName-${i}`),
+            path: getInputValue(`resourcePath-${i}`),
+            // @ts-ignore
+            compress: getInputValue(`compressResource-${i}`),
+          });
+          break;
+        }
+        case "ociImage": {
+          component.value["resources"].push({
+            // @ts-ignore
+            inputType: getInputValue(`resourceInputType-${i}`),
+            name: getInputValue(`resourceName-${i}`),
+            version: getInputValue(`resourceVersion-${i}`),
+            imageReference: getInputValue(`resourceImageReference-${i}`),
+          });
+        }
+      }
+    }
+  }
+
+  console.log("component", component);
+  postVSCodeMessage(component);
 });
+
+/**
+ *
+ * @param {number} i
+ */
+function addResourceForm(i) {
+  var div = document.createElement("div");
+  div.setAttribute("id", `resource-form-${i}`);
+  div.setAttribute("data-resource-counter", `${i}`);
+  div.innerHTML = `
+  <div>
+    <label class="header-label" for="resourceInputType-${i}">Resource Input Type</label><select name="resourceInputType-${i}" id="resourceInputType-${i}">
+      <option disabled selected value> -- select an option -- </option>
+			<option value="file">file</option>
+      <option value="directory">directory</option>
+      <option value="ociImage">ociImage</option>
+		</select>
+  </div>
+ `;
+
+  $addResourceButton.insertAdjacentElement("beforebegin", div);
+}
+
+/**
+ *
+ * @param {number} i
+ */
+function addFileResourceForm(i) {
+  const html = `
+  <div id="resource-fields-${i}">
+    <div>
+      <label class="header-label" for="resourceName-${i}">Resource Name</label><input type="text" name="resourceName-${i}" id="resourceName-${i}" />
+    </div>
+    <div>
+      <label class="header-label" for="resourceType-${i}">Resource Type</label><input type="text" name="resourceType-${i}" id="resourceType-${i}" />
+    </div>
+    <div>
+      <label class="header-label" for="resourceMediaType-${i}">Resource Media Type</label><input type="text" name="resourceMediaType-${i}" id="resourceMediaType-${i}" />
+    </div>
+    <div>
+      <label class="header-label" for="resourcePath-${i}">Resource Path</label>
+      <div>
+        <button type="button" id="filepicker-${i}" class="filepicker-button">Select...</button>
+        <span><input type="text" disabled id="resourcePath-${i}" name="resourcePath-${i}"/></span>
+      </div>
+    </div>
+    <div>
+      <label class="header-label" for="compressResource-${i}">Compress?</label><input type="checkbox" name="compressResource-${i}" id="compressResource-${i}">
+    </div>
+  </div>
+  `;
+
+  document.getElementById(`resource-form-${i}`)?.insertAdjacentHTML("beforeend", html);
+  document.getElementById(`filepicker-${i}`)?.addEventListener("click", (e) => {
+    const options = {
+      canSelectMany: false,
+      canSelectFiles: true,
+      canSelectFolders: false,
+      openLabel: "Select",
+    };
+
+    showOpenDialog(options, i);
+  });
+}
+
+/**
+ *
+ * @param {number} i
+ */
+function addDirectoryResourceForm(i) {
+  const html = `
+  <div id="resource-fields-${i}">
+    <div>
+      <label class="header-label" for="resourceName-${i}">Resource Name</label><input type="text" name="resourceName-${i}" id="resourceName-${i}" />
+    </div>
+    <div>
+      <label class="header-label" for="resourcePath-${i}">Resource Path</label>
+      <div>
+        <button type="button" id="filepicker-${1}" class="filepicker-button">Select...</button>
+        <span><input type="text" disabled id="resourcePath-${i}" name="resourcePath-${i}"/></span>
+      </div>
+    </div>
+    <div>
+      <label class="header-label" for="compressResource-${i}">Compress?</label><input type="checkbox" name="compressResource-${i}" id="compressResource-${i}">
+    </div>
+  </div>
+  `;
+
+  document.getElementById(`resource-form-${i}`)?.insertAdjacentHTML("beforeend", html);
+  document.getElementById(`filepicker-${1}`)?.addEventListener("click", (e) => {
+    const options = {
+      canSelectMany: false,
+      canSelectFiles: false,
+      canSelectFolders: true,
+      openLabel: "Select",
+    };
+
+    showOpenDialog(options, i);
+  });
+}
+
+/**
+ * @param {number} i
+ */
+function addOciImageResourceForm(i) {
+  const html = `
+  <div id="resource-fields-${i}">
+    <div>
+      <label class="header-label" for="resourceName-${i}">Resource Name</label><input type="text" name="resourceName-${i}" id="resourceName-${i}" />
+    </div>
+    <div>
+      <label class="header-label" for="resourceVersion-${i}">Version</label><input type="text" name="resourceVersion-${i}" id="resourceVersion-${i}" />
+    </div>
+    <div>
+      <label class="header-label" for="resourceImageReference-${i}">Image Reference</label><input type="text" name="resourceImageReference-${i}" id="resourceImageReference-${i}" />
+    </div>
+  </div>
+  `;
+
+  document.getElementById(`resource-form-${i}`)?.insertAdjacentHTML("beforeend", html);
+}
+
+/**
+ * Get text input value (by id).
+ * @param {string} inputId
+ * @returns {string | boolean} input value or empty string
+ */
+function getInputValue(inputId) {
+  return /** @type null | HTMLInputElement */ (document.getElementById(inputId))?.value || "";
+}
+
+// ────────────────────────────────────────────────────────────
+// ─── WEBVIEW MESSAGE HANDLING ───────────────────────────────
+// ────────────────────────────────────────────────────────────
 
 // ────────────────────────────────────────────────────────────
 /**
@@ -66,12 +281,17 @@ function showNotification(text, isModal = false) {
 }
 
 /**
- * Get text input value (by id).
- * @param {string} inputId
- * @returns {string} input value or empty string
+ * @param {import('vscode').OpenDialogOptions} options
+ * @param {number} resourceId
  */
-function getInputValue(inputId) {
-  return /** @type null | HTMLInputElement */ (document.getElementById(inputId))?.value || "";
+function showOpenDialog(options, resourceId) {
+  postVSCodeMessage({
+    type: "showOpenDialog",
+    value: {
+      options: options,
+      forResourceId: resourceId,
+    },
+  });
 }
 
 window.addEventListener("message", (event) => {
@@ -80,6 +300,11 @@ window.addEventListener("message", (event) => {
 
   switch (message.type) {
     case "updateWebviewContent": {
+      break;
+    }
+    case "openDialogResponse": {
+      const { fileUri, forResourceId } = message.value;
+      document.getElementById(`resourcePath-${forResourceId}`)?.setAttribute("value", fileUri);
       break;
     }
   }

--- a/media/createComponent/view.js
+++ b/media/createComponent/view.js
@@ -2,23 +2,9 @@
 
 const vscode = acquireVsCodeApi();
 
-// /**
-//  * @type {{
-//  * componentName: string;
-//  * version: string;
-//  * provider: string;
-//  * scheme: string;
-//  * resources: [];
-//  * }}
-//  */
-// const webviewTempState = {
-//   componentName: "",
-//   version: "",
-//   provider: "",
-//   scheme: "",
-// };
-
 let resourceCount = 0;
+let referenceCount = 0;
+let sourceCount = 0;
 
 // Generic component input ids
 const componentName = "componentName";
@@ -27,6 +13,10 @@ const provider = "provider";
 const scheme = "scheme";
 
 const $addResourceButton = /** @type HTMLButtonElement */ (document.getElementById("add-resource"));
+const $addReferenceButton = /** @type HTMLButtonElement */ (
+  document.getElementById("add-reference")
+);
+const $addSourceButton = /** @type HTMLButtonElement */ (document.getElementById("add-source"));
 const $submitBtn = /** @type HTMLButtonElement */ (document.getElementById("create-component"));
 
 $addResourceButton.addEventListener("click", () => {
@@ -59,6 +49,16 @@ $addResourceButton.addEventListener("click", () => {
   });
 
   resourceCount++;
+});
+
+$addSourceButton.addEventListener("click", () => {
+  addSourceForm(sourceCount);
+  sourceCount++;
+});
+
+$addReferenceButton.addEventListener("click", () => {
+  addReferenceForm(referenceCount);
+  referenceCount++;
 });
 
 $submitBtn.addEventListener("click", () => {
@@ -95,7 +95,6 @@ $submitBtn.addEventListener("click", () => {
       version: getInputValue(version),
       provider: getInputValue(provider),
       scheme: getInputValue(scheme),
-      resources: [],
     },
   };
 
@@ -103,7 +102,6 @@ $submitBtn.addEventListener("click", () => {
     component.value["resources"] = [];
     for (let i = 0; i < resourceCount; i++) {
       if (!document.getElementById(`resource-form-${i}`)) {
-        console.log("not found");
         continue;
       }
 
@@ -145,7 +143,39 @@ $submitBtn.addEventListener("click", () => {
     }
   }
 
-  console.log("component", component);
+  if (referenceCount > 0) {
+    component.value["references"] = [];
+    for (let i = 0; i < referenceCount; i++) {
+      if (!document.getElementById(`reference-form-${i}`)) {
+        continue;
+      }
+
+      component.value["references"].push({
+        name: getInputValue(`referenceName-${i}`),
+        componentName: getInputValue(`referenceComponentName-${i}`),
+        componentVersion: getInputValue(`referenceComponentVersion-${i}`),
+      });
+    }
+  }
+
+  if (sourceCount > 0) {
+    component.value["sources"] = [];
+    for (let i = 0; i < sourceCount; i++) {
+      if (!document.getElementById(`source-form-${i}`)) {
+        continue;
+      }
+
+      component.value["sources"].push({
+        name: getInputValue(`sourceName-${i}`),
+        version: getInputValue(`sourceVersion-${i}`),
+        // @ts-ignore
+        accessType: getInputValue(`sourceAccessType-${i}`),
+        repoUrl: getInputValue(`sourceRepoUrl-${i}`),
+        commit: getInputValue(`sourceCommit-${i}`),
+      });
+    }
+  }
+
   postVSCodeMessage(component);
 });
 
@@ -157,7 +187,9 @@ function addResourceForm(i) {
   var div = document.createElement("div");
   div.setAttribute("id", `resource-form-${i}`);
   div.setAttribute("data-resource-counter", `${i}`);
+  div.classList.add("addon-form");
   div.innerHTML = `
+  <h3>Add Resource</h3>
   <div>
     <label class="header-label" for="resourceInputType-${i}">Resource Input Type</label><select name="resourceInputType-${i}" id="resourceInputType-${i}">
       <option disabled selected value> -- select an option -- </option>
@@ -268,6 +300,64 @@ function addOciImageResourceForm(i) {
   `;
 
   document.getElementById(`resource-form-${i}`)?.insertAdjacentHTML("beforeend", html);
+}
+
+/**
+ *
+ * @param {number} i
+ */
+function addSourceForm(i) {
+  var div = document.createElement("div");
+  div.setAttribute("id", `source-form-${i}`);
+  div.setAttribute("data-source-counter", `${i}`);
+  div.classList.add("addon-form");
+  div.innerHTML = `
+  <h3>Add Source</h3>
+  <div>
+    <label class="header-label" for="sourceAccessType-${i}">Source Type</label><select name="sourceAccessType-${i}" id="sourceAccessType-${i}">
+      <option value="gitHub">GitHub</option>
+		</select>
+  </div>
+  <div>
+    <label class="header-label" for="sourceName-${i}">Source Name</label><input type="text" name="sourceName-${i}" id="sourceName-${i}" />
+  </div>
+  <div>
+    <label class="header-label" for="sourceVersion-${i}">Source Version</label><input type="text" name="sourceVersion-${i}" id="sourceVersion-${i}" />
+  </div>
+  <div>
+    <label class="header-label" for="sourceRepoUrl-${i}">Repo URL</label><input type="text" name="sourceRepoUrl-${i}" id="sourceRepoUrl-${i}" />
+  </div>
+  <div>
+    <label class="header-label" for="sourceCommit-${i}">Commit</label><input type="text" name="sourceCommit-${i}" id="sourceCommit-${i}" />
+  </div>
+  `;
+
+  $addSourceButton.insertAdjacentElement("beforebegin", div);
+}
+
+/**
+ *
+ * @param {number} i
+ */
+function addReferenceForm(i) {
+  var div = document.createElement("div");
+  div.setAttribute("id", `reference-form-${i}`);
+  div.setAttribute("data-reference-counter", `${i}`);
+  div.classList.add("addon-form");
+  div.innerHTML = `
+  <h3>Add Reference</h3>
+  <div>
+    <label class="header-label" for="referenceName-${i}">Reference Name</label><input type="text" name="referenceName-${i}" id="referenceName-${i}" />
+  </div>
+  <div>
+    <label class="header-label" for="referenceComponentName-${i}">Component Name</label><input type="text" name="referenceComponentName-${i}" id="referenceComponentName-${i}" />
+  </div>
+  <div>
+    <label class="header-label" for="referenceComponentVersion-${i}">Component Version</label><input type="text" name="referenceComponentVersion-${i}" id="referenceComponentVersion-${i}" />
+  </div>
+  `;
+
+  $addReferenceButton.insertAdjacentElement("beforebegin", div);
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "eslint": "^8.33.0",
         "extract-zip": "^2.0.1",
         "glob": "^8.1.0",
-        "js-yaml": "^4.1.0",
         "json-schema-to-typescript": "^11.0.3",
         "mocha": "^10.1.0",
         "request": "^2.88.2",

--- a/package.json
+++ b/package.json
@@ -77,12 +77,6 @@
         "title": "Transfer (copy resources)"
       },
       {
-        "command": "ocm.workspace.refresh",
-        "title": "Refresh",
-        "category": "Open Component Model",
-        "icon": "$(refresh)"
-      },
-      {
         "command": "ocm.remote.refresh",
         "title": "Refresh",
         "category": "Open Component Model",
@@ -147,16 +141,6 @@
     "menus": {
       "view/title": [
         {
-          "command": "ocm.remote.add",
-          "when": "view == ocm.views.remote",
-          "group": "navigation"
-        },
-        {
-          "command": "ocm.remote.refresh",
-          "when": "view == ocm.views.remote",
-          "group": "navigation"
-        },
-        {
           "command": "ocm.component-version.createView",
           "when": "view == ocm.views.workspace",
           "group": "navigation"
@@ -164,6 +148,16 @@
         {
           "command": "ocm.workspace.refresh",
           "when": "view == ocm.views.workspace",
+          "group": "navigation"
+        },
+        {
+          "command": "ocm.remote.add",
+          "when": "view == ocm.views.remote",
+          "group": "navigation"
+        },
+        {
+          "command": "ocm.remote.refresh",
+          "when": "view == ocm.views.remote",
           "group": "navigation"
         },
         {

--- a/package.json
+++ b/package.json
@@ -247,7 +247,6 @@
     "eslint": "^8.33.0",
     "extract-zip": "^2.0.1",
     "glob": "^8.1.0",
-    "js-yaml": "^4.1.0",
     "json-schema-to-typescript": "^11.0.3",
     "mocha": "^10.1.0",
     "request": "^2.88.2",

--- a/src/commands/addReference.ts
+++ b/src/commands/addReference.ts
@@ -1,25 +1,40 @@
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "fs";
 import { workspace } from "vscode";
+import YAML from "yaml";
+import { Reference } from "../ocm/ocmv3";
 import { output } from "../output";
-import { shell, ShellResult } from "../shell";
-import { Reference } from "../webviews/createComponent";
+import { shell } from "../shell";
 
 export interface AddReferenceResult {
   success: boolean;
   message: string;
 }
 
-export async function addReference(reference: Reference): Promise<AddReferenceResult> {
+export async function addReference(
+  reference: Reference,
+  componentPath: string
+): Promise<AddReferenceResult> {
   if (!workspace.workspaceFolders) {
     return { success: false, message: "No workspace folder found." };
   }
 
   const workspacePath = workspace.workspaceFolders[0].uri.toString().replace("file://", "");
-  const componentPath = `${workspacePath}/component-archive`;
+  const tempPath = `${workspacePath}/.ocm`;
 
-  const cmd = `ocm add reference ${componentPath} --name ${reference.name} --component ${reference.componentName} --version ${reference.componentVersion}`;
+  if (!existsSync(tempPath)) {
+    mkdirSync(tempPath);
+  }
 
   output.send(`Adding reference ${reference.name} to component-archive...`);
-  const result: ShellResult = await shell.exec(cmd);
+
+  const random = Math.random().toString(36).substring(7);
+  const filename = `${tempPath}/resource-${random}.yaml`;
+  writeFileSync(`${filename}`, YAML.stringify(reference));
+  const cmd = `ocm add reference ${componentPath} ${filename}`;
+  const result = await shell.exec(cmd);
+
+  // Remove the temporary file
+  unlinkSync(filename);
 
   if (result.code !== 0) {
     output.send(`Adding reference failed: ${result.stderr}`);

--- a/src/commands/addReference.ts
+++ b/src/commands/addReference.ts
@@ -1,0 +1,34 @@
+import { workspace } from "vscode";
+import { output } from "../output";
+import { shell, ShellResult } from "../shell";
+import { Reference } from "../webviews/createComponent";
+
+export interface AddReferenceResult {
+  success: boolean;
+  message: string;
+}
+
+export async function addReference(reference: Reference): Promise<AddReferenceResult> {
+  if (!workspace.workspaceFolders) {
+    return { success: false, message: "No workspace folder found." };
+  }
+
+  const workspacePath = workspace.workspaceFolders[0].uri.toString().replace("file://", "");
+  const componentPath = `${workspacePath}/component-archive`;
+
+  const cmd = `ocm add reference ${componentPath} --name ${reference.name} --component ${reference.componentName} --version ${reference.componentVersion}`;
+
+  output.send(`Adding reference ${reference.name} to component-archive...`);
+  const result: ShellResult = await shell.exec(cmd);
+
+  if (result.code !== 0) {
+    output.send(`Adding reference failed: ${result.stderr}`);
+    return { success: false, message: result.stderr };
+  }
+
+  result.stdout || result.stderr
+    ? output.send(`Adding reference complete: ${result.stdout || result.stderr}`)
+    : output.send(`Adding reference complete.`);
+
+  return { success: true, message: result.stdout || result.stderr };
+}

--- a/src/commands/addResources.ts
+++ b/src/commands/addResources.ts
@@ -1,0 +1,64 @@
+import { DirectoryResource, FileResource, OciImageResource } from "../webviews/createComponent";
+import { output } from "../output";
+import { shell, ShellResult } from "../shell";
+import { workspace } from "vscode";
+
+export interface AddResourceResult {
+  success: boolean;
+  message: string;
+}
+
+export async function addResource(
+  resource: FileResource | DirectoryResource | OciImageResource
+): Promise<AddResourceResult> {
+  if (!workspace.workspaceFolders) {
+    return { success: false, message: "No workspace folder found." };
+  }
+
+  const workspacePath = workspace.workspaceFolders[0].uri.toString().replace("file://", "");
+  const componentPath = `${workspacePath}/component-archive`;
+
+  let result: ShellResult;
+  switch (resource.inputType) {
+    case "file": {
+      const uri = resource.path;
+
+      let cmd = `ocm add resource ${componentPath} --type ${resource.type} --name ${resource.name} --inputType ${resource.inputType} --inputPath ${uri} --mediaType ${resource.mediaType}`;
+      if (resource.compress) {
+        cmd += ` --inputCompress`;
+      }
+      output.send(`Adding resource ${resource.name} to component-archive...`);
+      result = await shell.exec(cmd);
+      break;
+    }
+    case "directory": {
+      const uri = resource.path;
+
+      let cmd = `ocm add resource ${componentPath} --type ${resource.type} --name ${resource.name} --inputType dir --inputPath ${uri}`;
+      if (resource.compress) {
+        cmd += ` --inputCompress`;
+      }
+      output.send(`Adding resource ${resource.name} to component-archive...`);
+      result = await shell.exec(cmd);
+      break;
+    }
+    case "ociImage": {
+      const cmd = `ocm add resource ${componentPath} --type ociImage --name ${resource.name} --version ${resource.version} --accessType ociArtifact --reference ${resource.imageReference}`;
+
+      output.send(`Adding resource ${resource.name} to component-archive...`);
+      result = await shell.exec(cmd);
+      break;
+    }
+  }
+
+  if (result.code !== 0) {
+    output.send(`Adding resource failed: ${result.stderr}`);
+    return { success: false, message: result.stderr };
+  }
+
+  result.stdout || result.stderr
+    ? output.send(`Adding resource complete: ${result.stdout || result.stderr}`)
+    : output.send(`Adding resource complete!`);
+
+  return { success: true, message: result.stdout || result.stderr };
+}

--- a/src/commands/addSource.ts
+++ b/src/commands/addSource.ts
@@ -1,0 +1,39 @@
+import { workspace } from "vscode";
+import { output } from "../output";
+import { shell, ShellResult } from "../shell";
+import { GitHubSource } from "../webviews/createComponent";
+
+export interface AddSourceResult {
+  success: boolean;
+  message: string;
+}
+
+export async function addSource(source: GitHubSource): Promise<AddSourceResult> {
+  if (!workspace.workspaceFolders) {
+    return { success: false, message: "No workspace folder found." };
+  }
+
+  const workspacePath = workspace.workspaceFolders[0].uri.toString().replace("file://", "");
+  const componentPath = `${workspacePath}/component-archive`;
+
+  let result: ShellResult;
+  switch (source.accessType) {
+    case "gitHub": {
+      const cmd = `ocm add source ${componentPath} --type git --name ${source.name} --version ${source.version} --accessType ${source.accessType} --accessRepository ${source.repoUrl} --commit ${source.commit}`;
+
+      output.send(`Adding source ${source.name} to component-archive...`);
+      result = await shell.exec(cmd);
+    }
+  }
+
+  if (result.code !== 0) {
+    output.send(`Adding source failed: ${result.stderr}`);
+    return { success: false, message: result.stderr };
+  }
+
+  result.stdout || result.stderr
+    ? output.send(`Adding source complete: ${result.stdout || result.stderr}`)
+    : output.send(`Adding source complete.`);
+
+  return { success: true, message: result.stdout || result.stderr };
+}

--- a/src/commands/addSource.ts
+++ b/src/commands/addSource.ts
@@ -1,30 +1,38 @@
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "fs";
 import { workspace } from "vscode";
+import YAML from "yaml";
+import { SourceDefinition } from "../ocm/ocmv3";
 import { output } from "../output";
-import { shell, ShellResult } from "../shell";
-import { GitHubSource } from "../webviews/createComponent";
+import { shell } from "../shell";
 
 export interface AddSourceResult {
   success: boolean;
   message: string;
 }
 
-export async function addSource(source: GitHubSource): Promise<AddSourceResult> {
+export async function addSource(
+  source: SourceDefinition,
+  componentPath: string
+): Promise<AddSourceResult> {
   if (!workspace.workspaceFolders) {
     return { success: false, message: "No workspace folder found." };
   }
 
   const workspacePath = workspace.workspaceFolders[0].uri.toString().replace("file://", "");
-  const componentPath = `${workspacePath}/component-archive`;
+  const tempPath = `${workspacePath}/.ocm`;
 
-  let result: ShellResult;
-  switch (source.accessType) {
-    case "gitHub": {
-      const cmd = `ocm add source ${componentPath} --type git --name ${source.name} --version ${source.version} --accessType ${source.accessType} --accessRepository ${source.repoUrl} --commit ${source.commit}`;
-
-      output.send(`Adding source ${source.name} to component-archive...`);
-      result = await shell.exec(cmd);
-    }
+  if (!existsSync(tempPath)) {
+    mkdirSync(tempPath);
   }
+
+  const random = Math.random().toString(36).substring(7);
+  const filename = `${tempPath}/resource-${random}.yaml`;
+  writeFileSync(`${filename}`, YAML.stringify(source));
+  const cmd = `ocm add source ${componentPath} ${filename}`;
+  const result = await shell.exec(cmd);
+
+  // Remove the temporary file
+  unlinkSync(filename);
 
   if (result.code !== 0) {
     output.send(`Adding source failed: ${result.stderr}`);

--- a/src/commands/createComponent.ts
+++ b/src/commands/createComponent.ts
@@ -1,10 +1,11 @@
-import { existsSync, rmSync } from "fs";
+import { existsSync, mkdirSync, rmSync } from "fs";
 import { window, workspace } from "vscode";
 import { getExtensionContext } from "../extensionContext";
+import { Component } from "../ocm/types";
 import { output } from "../output";
 import { shell } from "../shell";
 import { workspaceTreeViewProvider } from "../views/treeViews";
-import { CreateComponent, CreateComponentPanel } from "../webviews/createComponent";
+import { CreateComponentPanel } from "../webviews/createComponent";
 import { addReference, AddReferenceResult } from "./addReference";
 import { addResource, AddResourceResult } from "./addResources";
 import { addSource, AddSourceResult } from "./addSource";
@@ -18,13 +19,19 @@ export interface CreateComponentResult {
   message: string;
 }
 
-export async function createComponent(component: CreateComponent): Promise<CreateComponentResult> {
+export async function createComponent(component: Component): Promise<CreateComponentResult> {
   if (!workspace.workspaceFolders) {
     return { success: false, message: "No workspace folder found." };
   }
 
-  const targetPath = workspace.workspaceFolders[0].uri.toString().replace("file://", "");
-  const outFile = `${targetPath}/component-archive`;
+  const workspacePath = workspace.workspaceFolders[0].uri.toString().replace("file://", "");
+  const outPath = `${workspacePath}/${component.path}`;
+
+  if (!existsSync(outPath)) {
+    mkdirSync(outPath, { recursive: true });
+  }
+
+  const outFile = `${outPath}/component-archive`;
 
   if (existsSync(outFile)) {
     const answer = await window.showWarningMessage(
@@ -44,10 +51,8 @@ export async function createComponent(component: CreateComponent): Promise<Creat
     rmSync(outFile, { recursive: true, force: true });
   }
 
-  const cmd = `ocm create componentarchive ${component.componentName} ${component.version} --provider ${component.provider} --scheme ${component.scheme} -F ${outFile}`;
-  output.send(
-    `Creating component ${component.componentName}:${component.version} to ${outFile}...`
-  );
+  const cmd = `ocm create componentarchive ${component.name} ${component.version} --provider ${component.provider?.name} --scheme ${component.scheme} -F ${outFile}`;
+  output.send(`Creating component ${component.name}:${component.version} to ${outFile}...`);
 
   const result = await shell.exec(cmd);
 
@@ -58,7 +63,7 @@ export async function createComponent(component: CreateComponent): Promise<Creat
 
   if (component.resources && component.resources.length > 0) {
     for (const resource of component.resources) {
-      const res: AddResourceResult = await addResource(resource);
+      const res: AddResourceResult = await addResource(resource, outFile);
       if (!res.success) {
         // return early if a resource could not be added.
         workspaceTreeViewProvider.refresh();
@@ -72,7 +77,7 @@ export async function createComponent(component: CreateComponent): Promise<Creat
 
   if (component.references && component.references.length > 0) {
     for (const reference of component.references) {
-      const res: AddReferenceResult = await addReference(reference);
+      const res: AddReferenceResult = await addReference(reference, outFile);
       if (!res.success) {
         // return early if a reference could not be added.
         workspaceTreeViewProvider.refresh();
@@ -86,7 +91,7 @@ export async function createComponent(component: CreateComponent): Promise<Creat
 
   if (component.sources && component.sources.length > 0) {
     for (const source of component.sources) {
-      const res: AddSourceResult = await addSource(source);
+      const res: AddSourceResult = await addSource(source, outFile);
       if (!res.success) {
         // return early if a source could not be added.
         workspaceTreeViewProvider.refresh();

--- a/src/commands/createComponent.ts
+++ b/src/commands/createComponent.ts
@@ -1,11 +1,13 @@
-import { shell } from "../shell";
-import { output } from "../output";
-import { addResource, AddResourceResult } from "./addResources";
-import { getExtensionContext } from "../extensionContext";
-import { CreateComponent, CreateComponentPanel } from "../webviews/createComponent";
-import { workspaceTreeViewProvider } from "../views/treeViews";
-import { window, workspace } from "vscode";
 import { existsSync, rmSync } from "fs";
+import { window, workspace } from "vscode";
+import { getExtensionContext } from "../extensionContext";
+import { output } from "../output";
+import { shell } from "../shell";
+import { workspaceTreeViewProvider } from "../views/treeViews";
+import { CreateComponent, CreateComponentPanel } from "../webviews/createComponent";
+import { addReference, AddReferenceResult } from "./addReference";
+import { addResource, AddResourceResult } from "./addResources";
+import { addSource, AddSourceResult } from "./addSource";
 
 export async function createComponentView() {
   CreateComponentPanel.createOrShow(getExtensionContext());
@@ -58,10 +60,39 @@ export async function createComponent(component: CreateComponent): Promise<Creat
     for (const resource of component.resources) {
       const res: AddResourceResult = await addResource(resource);
       if (!res.success) {
+        // return early if a resource could not be added.
         workspaceTreeViewProvider.refresh();
         return {
           success: false,
-          message: `Component creation failed: ${res.message}`,
+          message: `Component creation failed adding resource: ${res.message}`,
+        };
+      }
+    }
+  }
+
+  if (component.references && component.references.length > 0) {
+    for (const reference of component.references) {
+      const res: AddReferenceResult = await addReference(reference);
+      if (!res.success) {
+        // return early if a reference could not be added.
+        workspaceTreeViewProvider.refresh();
+        return {
+          success: false,
+          message: `Component creation failed adding reference: ${res.message}`,
+        };
+      }
+    }
+  }
+
+  if (component.sources && component.sources.length > 0) {
+    for (const source of component.sources) {
+      const res: AddSourceResult = await addSource(source);
+      if (!res.success) {
+        // return early if a source could not be added.
+        workspaceTreeViewProvider.refresh();
+        return {
+          success: false,
+          message: `Component creation failed adding source: ${res.message}`,
         };
       }
     }

--- a/src/commands/createComponent.ts
+++ b/src/commands/createComponent.ts
@@ -1,7 +1,8 @@
 import { shell } from "../shell";
 import { output } from "../output";
+import { addResource, AddResourceResult } from "./addResources";
 import { getExtensionContext } from "../extensionContext";
-import { CreateComponentPanel } from "../webviews/createComponent";
+import { CreateComponent, CreateComponentPanel } from "../webviews/createComponent";
 import { workspaceTreeViewProvider } from "../views/treeViews";
 import { window, workspace } from "vscode";
 import { existsSync, rmSync } from "fs";
@@ -10,14 +11,14 @@ export async function createComponentView() {
   CreateComponentPanel.createOrShow(getExtensionContext());
 }
 
-export async function createComponent(
-  name: string,
-  version: string,
-  provider: string,
-  scheme: string
-) {
+export interface CreateComponentResult {
+  success: boolean;
+  message: string;
+}
+
+export async function createComponent(component: CreateComponent): Promise<CreateComponentResult> {
   if (!workspace.workspaceFolders) {
-    return;
+    return { success: false, message: "No workspace folder found." };
   }
 
   const targetPath = workspace.workspaceFolders[0].uri.toString().replace("file://", "");
@@ -32,21 +33,46 @@ export async function createComponent(
 
     if (answer !== "Yes") {
       output.send(`Component creation cancelled, ${outFile} already exists.`);
-      return;
+      return {
+        success: false,
+        message: `Component creation cancelled. ${outFile} already exists.`,
+      };
     }
 
     rmSync(outFile, { recursive: true, force: true });
   }
 
-  const cmd = `ocm create componentarchive ${name} ${version} --provider ${provider} --scheme ${scheme} -F ${outFile}`;
-  output.send(`Creating component ${name}:${version} to ${outFile}...`);
+  const cmd = `ocm create componentarchive ${component.componentName} ${component.version} --provider ${component.provider} --scheme ${component.scheme} -F ${outFile}`;
+  output.send(
+    `Creating component ${component.componentName}:${component.version} to ${outFile}...`
+  );
 
   const result = await shell.exec(cmd);
-  result.code !== 0
-    ? output.send(`Component creation failed: ${result.stderr}`)
-    : result.stdout || result.stderr
-    ? output.send(`Component creation complete: ${result.stdout || result.stderr}`)
-    : output.send(`Component creation complete!`);
+
+  if (result.code !== 0) {
+    output.send(`Component creation failed: ${result.stderr}`);
+    return { success: false, message: "Create component failed: " + result.stderr };
+  }
+
+  if (component.resources && component.resources.length > 0) {
+    for (const resource of component.resources) {
+      const res: AddResourceResult = await addResource(resource);
+      if (!res.success) {
+        workspaceTreeViewProvider.refresh();
+        return {
+          success: false,
+          message: `Component creation failed: ${res.message}`,
+        };
+      }
+    }
+  }
 
   workspaceTreeViewProvider.refresh();
+
+  const message =
+    result.stdout || result.stderr
+      ? `Component creation complete: ${result.stdout || result.stderr}`
+      : `Component creation complete!`;
+  output.send(message);
+  return { success: true, message: message };
 }

--- a/src/ocm/types.ts
+++ b/src/ocm/types.ts
@@ -1,0 +1,33 @@
+import { Meta, OciImageResource, Reference, ResourceType, SourceDefinition } from "./ocmv3";
+
+export interface Component extends Meta {
+  scheme: "v2" | "v3alpha1";
+  path: string;
+  resources?: (Resource | OciArtifactResource)[];
+  sources?: SourceDefinition[];
+  references?: Reference[];
+}
+
+type NoStringIndex<T> = { [K in keyof T as string extends K ? never : K]: T[K] };
+
+export interface Resource extends Omit<NoStringIndex<ResourceType>, "version" | "type" | "access"> {
+  version?: string;
+  type?: string;
+  input: LocalFilesystemResourceInput;
+}
+
+export interface OciArtifactResource extends Omit<NoStringIndex<OciImageResource>, "access"> {
+  access: OciArtifactAccess;
+}
+
+export interface LocalFilesystemResourceInput {
+  type: "file" | "dir";
+  mediaType?: string;
+  path: string;
+  compress: boolean;
+}
+
+export interface OciArtifactAccess {
+  type: "ociArtifact";
+  imageReference: string;
+}

--- a/src/views/dataProviders/dataProvider.ts
+++ b/src/views/dataProviders/dataProvider.ts
@@ -1,81 +1,69 @@
-import { Event, EventEmitter, ExtensionContext, TreeDataProvider, TreeItem } from 'vscode';
-import { TreeNode } from '../nodes/treeNode';
+import { Event, EventEmitter, ExtensionContext, TreeDataProvider, TreeItem } from "vscode";
+import { TreeNode } from "../nodes/treeNode";
 
 /**
  * Defines tree view data provider base class for all GitOps tree views.
  */
 export class DataProvider implements TreeDataProvider<TreeItem> {
-    private treeItems: TreeItem[] | null = null;
-	private _onDidChangeTreeData: EventEmitter<TreeItem | undefined> = new EventEmitter<TreeItem | undefined>();
-	readonly onDidChangeTreeData: Event<TreeItem | undefined> = this._onDidChangeTreeData.event;
+  private _onDidChangeTreeData: EventEmitter<TreeItem | undefined | null | void> = new EventEmitter<
+    TreeItem | undefined | null | void
+  >();
+  readonly onDidChangeTreeData: Event<TreeItem | undefined | null | void> =
+    this._onDidChangeTreeData.event;
 
-	context: ExtensionContext;
+  context: ExtensionContext;
 
-	constructor(context: ExtensionContext) {
-		this.context = context;
-	}
-	
-	/**
-	 * Reloads tree view item and its children.
-	 * @param treeItem Tree item to refresh.
-	 */
-	public refresh(treeItem?: TreeItem) {
-		if (!treeItem) {
-			// Only clear all root nodes when no node was passed
-			this.treeItems = null;
-		}
-		this.buildTree();
-		this._onDidChangeTreeData.fire(treeItem);
-	}
+  constructor(context: ExtensionContext) {
+    this.context = context;
+  }
 
-	/**
-	 * Gets tree view item for the specified tree element.
-	 * @param element Tree element.
-	 * @returns Tree view item.
-	 */
-	public getTreeItem(element: TreeItem): TreeItem {
-		return element;
-	}
+  /**
+   * Reloads tree view item and its children.
+   */
+  public refresh() {
+    this._onDidChangeTreeData.fire();
+  }
 
-	/**
-	 * Gets tree element parent.
-	 * @param element Tree item to get parent for.
-	 * @returns Parent tree item or null for the top level nodes.
-	 */
-	public getParent(element: TreeItem): TreeItem | null {
-		if (element instanceof TreeNode && element.parent) {
-			return element.parent;
-		}
-		return null;
-	}
+  /**
+   * Gets tree view item for the specified tree element.
+   * @param element Tree element.
+   * @returns Tree view item.
+   */
+  public getTreeItem(element: TreeItem): TreeItem {
+    return element;
+  }
 
-	/**
-	 * Gets children for the specified tree element.
-	 * Creates new tree view items for the root node.
-	 * @param element The tree element to get children for.
-	 * @returns Tree element children or empty array.
-	 */
-	public async getChildren(element?: TreeItem): Promise<TreeItem[]> {
-		if (!this.treeItems) {
-			this.treeItems = await this.buildTree();
-		}
+  /**
+   * Gets tree element parent.
+   * @param element Tree item to get parent for.
+   * @returns Parent tree item or null for the top level nodes.
+   */
+  public getParent(element: TreeItem): TreeItem | null {
+    if (element instanceof TreeNode && element.parent) {
+      return element.parent;
+    }
+    return null;
+  }
 
-		if (element instanceof TreeNode) {
-			return element.children;
-		}
+  /**
+   * Gets children for the specified tree element.
+   * Creates new tree view items for the root node.
+   * @param element The tree element to get children for.
+   * @returns Tree element children or empty array.
+   */
+  public async getChildren(element?: TreeItem): Promise<TreeItem[]> {
+    if (element instanceof TreeNode) {
+      return element.children;
+    } else {
+      return await this.buildTree();
+    }
+  }
 
-		if (!element && this.treeItems) {
-			return this.treeItems;
-		}
-
-		return [];
-	}
-
-	/**
-	 * Creates initial tree view items collection.
-	 * @returns
-	 */
-	buildTree(): Promise<TreeNode[]> {
-		return Promise.resolve([]);
-	}
+  /**
+   * Creates initial tree view items collection.
+   * @returns
+   */
+  buildTree(): Promise<TreeNode[]> {
+    return Promise.resolve([]);
+  }
 }

--- a/src/views/treeViews.ts
+++ b/src/views/treeViews.ts
@@ -1,10 +1,8 @@
-import { TreeItem, TreeView, window, commands } from 'vscode';
-import { WorkspaceDataProvider } from './dataProviders/workspaceDataProvider';
-import { RemoteDataProvider } from './dataProviders/remoteDataProvider';
-import { ExtensionContext } from 'vscode';
-import { Views } from './views';
-import { TreeNode } from './nodes/treeNode';
-import { KeyDataProvider } from './dataProviders/keyDataProvider';
+import { ExtensionContext, TreeItem, TreeView, window } from "vscode";
+import { KeyDataProvider } from "./dataProviders/keyDataProvider";
+import { RemoteDataProvider } from "./dataProviders/remoteDataProvider";
+import { WorkspaceDataProvider } from "./dataProviders/workspaceDataProvider";
+import { Views } from "./views";
 
 export let workspaceTreeViewProvider: WorkspaceDataProvider;
 export let remoteTreeViewProvider: RemoteDataProvider;
@@ -15,39 +13,39 @@ let remoteTreeView: TreeView<TreeItem>;
 let keyTreeView: TreeView<TreeItem>;
 
 export function createTreeViews(context: ExtensionContext) {
-	workspaceTreeViewProvider = new WorkspaceDataProvider(context);
-	workspaceTreeView = window.createTreeView(Views.workspaceView, {
-		treeDataProvider: workspaceTreeViewProvider,
-		showCollapseAll: true,
-	});
+  workspaceTreeViewProvider = new WorkspaceDataProvider(context);
+  workspaceTreeView = window.createTreeView(Views.workspaceView, {
+    treeDataProvider: workspaceTreeViewProvider,
+    showCollapseAll: true,
+  });
 
-	remoteTreeViewProvider = new RemoteDataProvider(context);
-	remoteTreeView = window.createTreeView(Views.remoteView, {
-		treeDataProvider: remoteTreeViewProvider,
-		showCollapseAll: true,
-	});
+  remoteTreeViewProvider = new RemoteDataProvider(context);
+  remoteTreeView = window.createTreeView(Views.remoteView, {
+    treeDataProvider: remoteTreeViewProvider,
+    showCollapseAll: true,
+  });
 
-	keyTreeViewProvider = new KeyDataProvider(context);
-	keyTreeView = window.createTreeView(Views.keysView, {
-		treeDataProvider: keyTreeViewProvider,
-		showCollapseAll: true,
-	});
+  keyTreeViewProvider = new KeyDataProvider(context);
+  keyTreeView = window.createTreeView(Views.keysView, {
+    treeDataProvider: keyTreeViewProvider,
+    showCollapseAll: true,
+  });
 }
 
 export function refreshAllTreeViews() {
-	refreshWorkspaceTreeView();
-	refreshRemoteTreeView();
-	refreshKeyTreeView();
+  refreshWorkspaceTreeView();
+  refreshRemoteTreeView();
+  refreshKeyTreeView();
 }
 
-export function refreshWorkspaceTreeView(node?: TreeNode) {
-	workspaceTreeViewProvider.refresh(node);
+export function refreshWorkspaceTreeView() {
+  workspaceTreeViewProvider.refresh();
 }
 
-export function refreshRemoteTreeView(node?: TreeNode) {
-	remoteTreeViewProvider.refresh(node);
+export function refreshRemoteTreeView() {
+  remoteTreeViewProvider.refresh();
 }
 
-export function refreshKeyTreeView(node?: TreeNode) {
-	keyTreeViewProvider.refresh(node);
+export function refreshKeyTreeView() {
+  keyTreeViewProvider.refresh();
 }

--- a/src/webviews/createComponent.ts
+++ b/src/webviews/createComponent.ts
@@ -12,6 +12,7 @@ import {
 import { createComponent } from "../commands/createComponent";
 import { asAbsolutePath } from "../extensionContext";
 import { GlobalState } from "../globalState";
+import { Component } from "../ocm/types";
 import { getNonce, getWebviewOptions } from "./webviewUtils";
 
 /**
@@ -30,57 +31,9 @@ interface OpenDialogResponse {
   };
 }
 
-export interface FileResource {
-  inputType: "file";
-  name: string;
-  type: string;
-  mediaType: string;
-  path: string;
-  compress: boolean;
-}
-
-export interface DirectoryResource {
-  inputType: "directory";
-  name: string;
-  type: string;
-  path: string;
-  compress: boolean;
-}
-
-export interface OciImageResource {
-  inputType: "ociImage";
-  name: string;
-  version: string;
-  imageReference: string;
-}
-
-export interface GitHubSource {
-  name: string;
-  version: string;
-  accessType: "gitHub";
-  repoUrl: string;
-  commit: string;
-}
-
-export interface Reference {
-  name: string;
-  componentName: string;
-  componentVersion: string;
-}
-
-export interface CreateComponent {
-  componentName: string;
-  version: string;
-  provider: string;
-  scheme: string;
-  resources?: Array<FileResource | DirectoryResource | OciImageResource>;
-  references?: Array<Reference>;
-  sources?: Array<GitHubSource>;
-}
-
 export interface CreateComponentMessage {
   type: "createComponent";
-  value: CreateComponent;
+  value: Component;
 }
 
 export interface ShowNotification {
@@ -170,7 +123,7 @@ export class CreateComponentPanel {
       async (message: MessageFromWebview) => {
         switch (message.type) {
           case "createComponent":
-            const msg = `Creating component ${message.value.componentName}:${message.value.version}`;
+            const msg = `Creating component ${message.value.name}:${message.value.version}`;
             window.showInformationMessage(msg, { modal: false });
 
             const res = await createComponent(message.value);

--- a/src/webviews/createComponent.ts
+++ b/src/webviews/createComponent.ts
@@ -9,7 +9,6 @@ import {
   WebviewPanel,
   window,
 } from "vscode";
-import { addResource } from "../commands/addResources";
 import { createComponent } from "../commands/createComponent";
 import { asAbsolutePath } from "../extensionContext";
 import { GlobalState } from "../globalState";
@@ -55,12 +54,28 @@ export interface OciImageResource {
   imageReference: string;
 }
 
+export interface GitHubSource {
+  name: string;
+  version: string;
+  accessType: "gitHub";
+  repoUrl: string;
+  commit: string;
+}
+
+export interface Reference {
+  name: string;
+  componentName: string;
+  componentVersion: string;
+}
+
 export interface CreateComponent {
   componentName: string;
   version: string;
   provider: string;
   scheme: string;
   resources?: Array<FileResource | DirectoryResource | OciImageResource>;
+  references?: Array<Reference>;
+  sources?: Array<GitHubSource>;
 }
 
 export interface CreateComponentMessage {


### PR DESCRIPTION
Enable users to add resources, sources, and references within the Create Component UI flow.

- [x] Add resources (file, directory, ociImage)
- [x] Add sources
- [x] Add references

Changes:

- Added buttons for "Add Resource", "Add Source", and "Add Reference"
- Adding a resources allows the user to specify a resource type, current supported types are "file", "directory", and "ociImage".
- Adding a source currently support a gitHub source.
- Adding a reference supports a basic reference specification of `name`, `version`, and `componentName`. Support for specifying a digest can be completed later.
- If an error occurs adding any of the above the process exits early and the user will need to rectify.

Current Limitations:

- Once you add a resource, source, or reference, you can't remove them. This requires some additional considerations.
- Only basic input validation is completed, which only validates that the fields are not empty.
