### PR TITLE
keep the previously provided repo url in add component

### DIFF
--- a/component-archive/component-descriptor.yaml
+++ b/component-archive/component-descriptor.yaml
@@ -1,0 +1,17 @@
+apiVersion: ocm.software/v3alpha1
+kind: ComponentVersion
+metadata:
+  name: mickey.dev/podinfo
+  provider:
+    name: mickey.dev
+  version: 6.2.3
+repositoryContexts: []
+spec:
+  sources:
+  - access:
+      commit: 727513969553bfcc603e1c0ae1a75d79e4132b58
+      repoUrl: github.com/weaveworks/weave-gitops
+      type: gitHub
+    name: weave-gitops
+    type: git
+    version: 0.14.0

--- a/media/addComponent/view.js
+++ b/media/addComponent/view.js
@@ -75,7 +75,7 @@ window.addEventListener("message", (event) => {
 
   switch (message.type) {
     case "updateWebviewContent": {
-      $repository.value = message.value.repositoryUrl;
+      $repository.value = message.value.repositoryUrl || "";
       break;
     }
   }

--- a/media/addComponent/view.js
+++ b/media/addComponent/view.js
@@ -34,6 +34,11 @@ $submitButton.addEventListener("click", () => {
   });
 });
 
+postVSCodeMessage({
+  type: "init-view",
+  value: true,
+});
+
 // ────────────────────────────────────────────────────────────
 /**
  * @param message {import('../../src/webviews/addComponent').MessageFromWebview}
@@ -70,6 +75,7 @@ window.addEventListener("message", (event) => {
 
   switch (message.type) {
     case "updateWebviewContent": {
+      $repository.value = message.value.repositoryUrl;
       break;
     }
   }

--- a/src/globalState.ts
+++ b/src/globalState.ts
@@ -1,53 +1,54 @@
-import { ExtensionContext, window, workspace } from 'vscode';
+import { ExtensionContext, window, workspace } from "vscode";
 
-const enum GlobalStatePrefixes {
-}
+const enum GlobalStatePrefixes {}
 
 export const enum GlobalStateKey {
-	// eslint-disable-next-line @typescript-eslint/naming-convention
-	Components = 'components',
-	// eslint-disable-next-line @typescript-eslint/naming-convention
-	FirstEverActivationStorageKey = 'firstEverActivation',
-	// eslint-disable-next-line @typescript-eslint/naming-convention
-	OCMPath = 'ocm-path',
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  Components = "components",
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  FirstEverActivationStorageKey = "firstEverActivation",
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  OCMPath = "ocm-path",
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  DefaultRepositoryURL = "default-repository-url",
 }
 
 interface GlobalStateKeyMapping {
-	[GlobalStateKey.Components]: string[];
-	[GlobalStateKey.FirstEverActivationStorageKey]: boolean;
-	[GlobalStateKey.OCMPath]: string;
+  [GlobalStateKey.Components]: string[];
+  [GlobalStateKey.FirstEverActivationStorageKey]: boolean;
+  [GlobalStateKey.OCMPath]: string;
+  [GlobalStateKey.DefaultRepositoryURL]: string;
 }
 
 export class GlobalState {
+  constructor(private context: ExtensionContext) {}
 
-	constructor(private context: ExtensionContext) {}
+  get<T extends GlobalStateKeyMapping, E extends keyof T>(stateKey: E): T[E] | undefined {
+    return this.context.globalState.get(stateKey as string);
+  }
 
-	get<T extends GlobalStateKeyMapping, E extends keyof T>(stateKey: E): T[E] | undefined {
-		return this.context.globalState.get(stateKey as string);
-	}
+  set<T extends GlobalStateKeyMapping, E extends keyof T>(stateKey: E, newValue: T[E]): void {
+    this.context.globalState.update(stateKey as string, newValue);
+  }
 
-	set<T extends GlobalStateKeyMapping, E extends keyof T>(stateKey: E, newValue: T[E]): void {
-		this.context.globalState.update(stateKey as string, newValue);
-	}
+  /**
+   * Run while developing to see the entire global storage contents.
+   */
+  async showGlobalStateValue() {
+    const document = await workspace.openTextDocument({
+      language: "jsonc",
+      // @ts-ignore
+      content: JSON.stringify(this.context.globalState._value, null, "  "),
+    });
+    window.showTextDocument(document);
+  }
 
-	/**
-	 * Run while developing to see the entire global storage contents.
-	 */
-	async showGlobalStateValue() {
-		const document = await workspace.openTextDocument({
-			language: 'jsonc',
-			// @ts-ignore
-			content: JSON.stringify(this.context.globalState._value, null, '  '),
-		});
-		window.showTextDocument(document);
-	}
-
-	/**
-	 * Dev function (clear all global state properties).
-	 */
-	clearGlobalState() {
-		for (const key of this.context.globalState.keys()) {
-			this.context.globalState.update(key, undefined);
-		}
-	}
+  /**
+   * Dev function (clear all global state properties).
+   */
+  clearGlobalState() {
+    for (const key of this.context.globalState.keys()) {
+      this.context.globalState.update(key, undefined);
+    }
+  }
 }

--- a/src/webviews/addComponent.ts
+++ b/src/webviews/addComponent.ts
@@ -1,205 +1,242 @@
-import { readFileSync } from 'fs';
-import { Disposable, ExtensionContext, Uri, ViewColumn, Webview, WebviewPanel, window } from 'vscode';
-import { getNonce, getWebviewOptions } from './webviewUtils';
-import { asAbsolutePath } from '../extensionContext';
-import { GlobalState, GlobalStateKey } from '../globalState';
-import { remoteTreeViewProvider } from '../views/treeViews';
+import { readFileSync } from "fs";
+import {
+  Disposable,
+  ExtensionContext,
+  Uri,
+  ViewColumn,
+  Webview,
+  WebviewPanel,
+  window,
+} from "vscode";
+import { asAbsolutePath } from "../extensionContext";
+import { GlobalState, GlobalStateKey } from "../globalState";
+import { remoteTreeViewProvider } from "../views/treeViews";
+import { getNonce, getWebviewOptions } from "./webviewUtils";
 /**
  * Message sent to webview to initialize it.
  */
 interface AddComponentWebviewContent {
-	type: 'updateWebviewContent';
-	value: {};
+  type: "updateWebviewContent";
+  value: {
+    repositoryUrl: string;
+  };
 }
 
 export interface AddComponent {
-	type: 'addComponent';
-	value: {
-		repositoryURL: string;
-		componentName: string;
-	};
+  type: "addComponent";
+  value: {
+    repositoryURL: string;
+    componentName: string;
+  };
 }
 
 export interface ShowNotification {
-	type: 'showNotification';
-	value: {
-		text: string;
-		isModal: boolean;
-	};
+  type: "showNotification";
+  value: {
+    text: string;
+    isModal: boolean;
+  };
 }
 
 export interface WebviewLoaded {
-	type: 'webviewLoaded';
-	value: true;
+  type: "webviewLoaded";
+  value: true;
+}
+
+export interface InitView {
+  type: "init-view";
+  value: true;
 }
 
 /** Message sent from Extension to Webview */
 export type MessageToWebview = AddComponentWebviewContent;
 
 /** Message sent from Webview to Extension */
-export type MessageFromWebview = AddComponent | ShowNotification | WebviewLoaded;
+export type MessageFromWebview = AddComponent | ShowNotification | WebviewLoaded | InitView;
 
 /**
  * Manages create source webview panel.
  */
 export class AddComponentPanel {
-	/**
-	 * Track the currently panel. Only allow a single panel to exist at a time.
-	 */
-	public static currentPanel: AddComponentPanel | undefined;
+  /**
+   * Track the currently panel. Only allow a single panel to exist at a time.
+   */
+  public static currentPanel: AddComponentPanel | undefined;
 
-	public static readonly viewType = 'addComponent';
+  public static readonly viewType = "addComponent";
 
-	private readonly _panel: WebviewPanel;
-	private readonly _extensionUri: Uri;
-	private _disposables: Disposable[] = [];
+  private readonly _panel: WebviewPanel;
+  private readonly _extensionUri: Uri;
+  private _disposables: Disposable[] = [];
 
-	private state: GlobalState;
-	/** Only send message to webview when it's ready (html parsed, "message" event listener set) */
-	private _onWebviewFinishedLoading = () => { };
+  private state: GlobalState;
+  /** Only send message to webview when it's ready (html parsed, "message" event listener set) */
+  private _onWebviewFinishedLoading = () => {};
 
-	public static createOrShow(context: ExtensionContext) {
-		const column = window.activeTextEditor ? window.activeTextEditor.viewColumn : undefined;
-		let extensionUri: Uri = context.extensionUri;
+  public static createOrShow(context: ExtensionContext) {
+    const column = window.activeTextEditor ? window.activeTextEditor.viewColumn : undefined;
+    let extensionUri: Uri = context.extensionUri;
 
-		// If we already have a panel, show it.
-		if (AddComponentPanel.currentPanel) {
-			AddComponentPanel.currentPanel._panel.reveal(column);
-			return;
-		}
+    // If we already have a panel, show it.
+    if (AddComponentPanel.currentPanel) {
+      AddComponentPanel.currentPanel._panel.reveal(column);
+      return;
+    }
 
-		// Otherwise, create a new panel.
-		const panel = window.createWebviewPanel(
-			AddComponentPanel.viewType,
-			'Add Component',
-			column || ViewColumn.One,
-			getWebviewOptions(extensionUri),
-		);
+    // Otherwise, create a new panel.
+    const panel = window.createWebviewPanel(
+      AddComponentPanel.viewType,
+      "Add Component",
+      column || ViewColumn.One,
+      getWebviewOptions(extensionUri)
+    );
 
-		AddComponentPanel.currentPanel = new AddComponentPanel(panel, extensionUri, context);
-	}
+    AddComponentPanel.currentPanel = new AddComponentPanel(panel, extensionUri, context);
+  }
 
-	public static revive(panel: WebviewPanel, extensionUri: Uri, context: ExtensionContext) {
-		AddComponentPanel.currentPanel = new AddComponentPanel(panel, extensionUri, context);
-	}
+  public static revive(panel: WebviewPanel, extensionUri: Uri, context: ExtensionContext) {
+    AddComponentPanel.currentPanel = new AddComponentPanel(panel, extensionUri, context);
+  }
 
-	private constructor(panel: WebviewPanel, extensionUri: Uri, context: ExtensionContext) {
-		this._panel = panel;
-		this._extensionUri = extensionUri;
-		this.state = new GlobalState(context);
+  private constructor(panel: WebviewPanel, extensionUri: Uri, context: ExtensionContext) {
+    this._panel = panel;
+    this._extensionUri = extensionUri;
+    this.state = new GlobalState(context);
 
-		// Set the webview's initial html content
-		this._update();
+    // Set the webview's initial html content
+    this._update();
 
-		// Listen for when the panel is disposed
-		// This happens when the user closes the panel or when the panel is closed programmatically
-		this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
+    // Listen for when the panel is disposed
+    // This happens when the user closes the panel or when the panel is closed programmatically
+    this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
 
-		// Update the content based on view changes
-		this._panel.onDidChangeViewState(e => {
-			console.log(e);
-			if (this._panel.visible) {
-				this._update();
-			}
-		}, null, this._disposables);
+    // Update the content based on view changes
+    this._panel.onDidChangeViewState(
+      (e) => {
+        console.log(e);
+        if (this._panel.visible) {
+          this._update();
+        }
+      },
+      null,
+      this._disposables
+    );
 
-		// Handle messages from the webview
-		this._panel.webview.onDidReceiveMessage(async (message: MessageFromWebview) => {
-			switch (message.type) {
-				case 'addComponent': {
-					//TODO:  validation before adding component to remote list
-					const component = `${message.value.repositoryURL}//${message.value.componentName}`;
-					const msg = `Added component ${component}`;
+    // Handle messages from the webview
+    this._panel.webview.onDidReceiveMessage(
+      async (message: MessageFromWebview) => {
+        switch (message.type) {
+          case "addComponent": {
+            //TODO:  validation before adding component to remote list
+            const component = `${message.value.repositoryURL}//${message.value.componentName}`;
+            const msg = `Added component ${component}`;
 
-					let updatedComponents: string[];
-					let existingComponents: string[] | undefined = this.state.get(GlobalStateKey.Components);
+            let updatedComponents: string[];
+            let existingComponents: string[] | undefined = this.state.get(
+              GlobalStateKey.Components
+            );
 
-					if (!existingComponents) {
-						updatedComponents = [component];
-					} else {
-						updatedComponents = existingComponents.concat(component);
-					}
+            if (!existingComponents) {
+              updatedComponents = [component];
+            } else {
+              updatedComponents = existingComponents.concat(component);
+            }
 
-					this.state.set(GlobalStateKey.Components, updatedComponents);
+            this.state.set(GlobalStateKey.Components, updatedComponents);
 
-					remoteTreeViewProvider.refresh();
+            remoteTreeViewProvider.refresh();
 
-					window.showInformationMessage(msg, {
-						modal: false,
-					});
+            window.showInformationMessage(msg, {
+              modal: false,
+            });
 
-					this.dispose();
-					break;
-				}
-				case 'showNotification': {
-					window.showInformationMessage(message.value.text, {
-						modal: message.value.isModal,
-					});
-					break;
-				}
-				case 'webviewLoaded': {
-					this._onWebviewFinishedLoading();
-					break;
-				}
-			}
-		},
-			null,
-			this._disposables,
-		);
-	}
+            this.state.set(GlobalStateKey.DefaultRepositoryURL, message.value.repositoryURL);
 
-	public dispose() {
-		AddComponentPanel.currentPanel = undefined;
+            this.dispose();
+            break;
+          }
+          case "showNotification": {
+            window.showInformationMessage(message.value.text, {
+              modal: message.value.isModal,
+            });
+            break;
+          }
+          case "webviewLoaded": {
+            this._onWebviewFinishedLoading();
+            break;
+          }
+          case "init-view": {
+            this._panel.webview.postMessage({
+              type: "updateWebviewContent",
+              value: {
+                repositoryUrl: this.state.get(GlobalStateKey.DefaultRepositoryURL),
+              },
+            });
+            break;
+          }
+        }
+      },
+      null,
+      this._disposables
+    );
+  }
 
-		// Clean up our resources
-		this._panel.dispose();
+  public dispose() {
+    AddComponentPanel.currentPanel = undefined;
 
-		while (this._disposables.length) {
-			const x = this._disposables.pop();
-			if (x) {
-				x.dispose();
-			}
-		}
-	}
+    // Clean up our resources
+    this._panel.dispose();
 
-	private _postMessage(message: MessageToWebview) {
-		this._panel.webview.postMessage(message);
-	}
+    while (this._disposables.length) {
+      const x = this._disposables.pop();
+      if (x) {
+        x.dispose();
+      }
+    }
+  }
 
-	private async _updateWebviewContent() {
-	}
+  private _postMessage(message: MessageToWebview) {
+    this._panel.webview.postMessage(message);
+  }
 
-	/**
-	 * Set webview html and send a message to update the contents.
-	 */
-	private async _update() {
-		this._onWebviewFinishedLoading = () => {
-			this._updateWebviewContent();
-			this._onWebviewFinishedLoading = () => { };
-		};
-		this._panel.webview.html = this._getHtmlForWebview(this._panel.webview);
-	}
+  private async _updateWebviewContent() {}
 
-	private _getHtmlForWebview(webview: Webview) {
-		// Local path to main script run in the webview
-		const scriptPathOnDisk = Uri.joinPath(this._extensionUri, 'media', 'addComponent', 'view.js');
+  /**
+   * Set webview html and send a message to update the contents.
+   */
+  private async _update() {
+    this._onWebviewFinishedLoading = () => {
+      this._updateWebviewContent();
+      this._onWebviewFinishedLoading = () => {};
+    };
+    this._panel.webview.html = this._getHtmlForWebview(this._panel.webview);
+  }
 
-		// And the uri we use to load this script in the webview
-		const scriptUri = webview.asWebviewUri(scriptPathOnDisk);
+  private _getHtmlForWebview(webview: Webview) {
+    // Local path to main script run in the webview
+    const scriptPathOnDisk = Uri.joinPath(this._extensionUri, "media", "addComponent", "view.js");
 
-		// Local path to css styles
-		const styleResetPath = Uri.joinPath(this._extensionUri, 'media', 'reset.css');
-		const styleVSCodePath = Uri.joinPath(this._extensionUri, 'media', 'vscode.css');
-		const stylesPathMainPath = Uri.joinPath(this._extensionUri, 'media', 'addComponent', 'view.css');
+    // And the uri we use to load this script in the webview
+    const scriptUri = webview.asWebviewUri(scriptPathOnDisk);
 
-		// Uri to load styles into webview
-		const stylesResetUri = webview.asWebviewUri(styleResetPath);
-		const stylesVSCodeUri = webview.asWebviewUri(styleVSCodePath);
-		const stylesMainUri = webview.asWebviewUri(stylesPathMainPath);
+    // Local path to css styles
+    const styleResetPath = Uri.joinPath(this._extensionUri, "media", "reset.css");
+    const styleVSCodePath = Uri.joinPath(this._extensionUri, "media", "vscode.css");
+    const stylesPathMainPath = Uri.joinPath(
+      this._extensionUri,
+      "media",
+      "addComponent",
+      "view.css"
+    );
 
-		// Use a nonce to only allow specific scripts to be run
-		const nonce = getNonce();
-		return `<!DOCTYPE html>
+    // Uri to load styles into webview
+    const stylesResetUri = webview.asWebviewUri(styleResetPath);
+    const stylesVSCodeUri = webview.asWebviewUri(styleVSCodePath);
+    const stylesMainUri = webview.asWebviewUri(stylesPathMainPath);
+
+    // Use a nonce to only allow specific scripts to be run
+    const nonce = getNonce();
+    return `<!DOCTYPE html>
 			<html lang="en">
 			<head>
 				<meta charset="UTF-8">
@@ -207,7 +244,9 @@ export class AddComponentPanel {
 					Use a content security policy to only allow loading images from https or from our extension directory,
 					and only allow scripts that have a specific nonce.
 				-->
-				<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource}; img-src ${webview.cspSource} https:; script-src 'nonce-${nonce}';">
+				<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${
+          webview.cspSource
+        }; img-src ${webview.cspSource} https:; script-src 'nonce-${nonce}';">
 
 				<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
@@ -219,10 +258,10 @@ export class AddComponentPanel {
 			</head>
 			<body>
 				<main class="app">
-					${readFileSync(asAbsolutePath('./media/addComponent/view.html').fsPath).toString()}
+					${readFileSync(asAbsolutePath("./media/addComponent/view.html").fsPath).toString()}
 				</main>
 				<script nonce="${nonce}" src="${scriptUri}" defer></script>
 			</body>
 			</html>`;
-	}
+  }
 }


### PR DESCRIPTION
Related to #38 

Default to the previously provided repository url in the add component view.

Example:

Add a component:
![image](https://github.com/open-component-model/vscode-ocm-tools/assets/7720995/aa4fdadb-0465-48df-b137-0324ac6a6db8)

After I click add and the component is downloaded:
![image](https://github.com/open-component-model/vscode-ocm-tools/assets/7720995/2b104e08-c5bc-4446-9d86-9f49bfe2c3da)


Click add component again and the repo URL is already filled:
![image](https://github.com/open-component-model/vscode-ocm-tools/assets/7720995/75b567ee-22ff-4749-9069-c89c2f19e7a4)
