### PR TITLE
add context menu to registry in remote list

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,10 @@
         "icon": "$(add)"
       },
       {
+        "command": "ocm.remote.addFromRegistry",
+        "title": "Add Component from Registry"
+      },
+      {
         "command": "ocm.remote.remove",
         "title": "Remove Component"
       },
@@ -139,6 +143,12 @@
       }
     ],
     "menus": {
+      "commandPalette": [
+        {
+          "command": "ocm.remote.addFromRegistry",
+          "when": "false"
+        }
+      ],
       "view/title": [
         {
           "command": "ocm.component-version.createView",
@@ -191,6 +201,11 @@
           "command": "ocm.component-version.transfer-by-value",
           "when": "viewItem =~ /ComponentVersion;/",
           "group": "navigation@1"
+        },
+        {
+          "command": "ocm.remote.addFromRegistry",
+          "when": "view == ocm.views.remote && viewItem =~ /Registry;/",
+          "group": "navigation@0"
         },
         {
           "command": "ocm.remote.remove",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,5 +1,5 @@
 import { commands } from "vscode";
-import { addRemoteComponent } from "./commands/addRemoteComponent";
+import { addRemoteComponent, addRemoteComponentFromRegistry } from "./commands/addRemoteComponent";
 import { createComponent, createComponentView } from "./commands/createComponent";
 import { createSigningKeys, createSigningKeysView } from "./commands/createSigningKeys";
 import { deleteSigningKeys } from "./commands/deleteSigningKeys";
@@ -7,12 +7,12 @@ import { downloadComponent } from "./commands/downloadComponent";
 import { downloadResource } from "./commands/downloadResource";
 import { openDocument } from "./commands/openDocuments";
 import { removeRemoteComponent } from "./commands/removeRemoteComponent";
-import { refreshRemoteTreeView, refreshWorkspaceTreeView } from "./views/treeViews";
+import { showNewUserGuide } from "./commands/showNewUserGuide";
 import { signComponent } from "./commands/signComponent";
 import { transferComponent } from "./commands/transferComponent";
-import { verifyComponent } from "./commands/verifyComponent";
 import { transferComponentByValue } from "./commands/transferComponentByValue";
-import { showNewUserGuide } from "./commands/showNewUserGuide";
+import { verifyComponent } from "./commands/verifyComponent";
+import { refreshRemoteTreeView, refreshWorkspaceTreeView } from "./views/treeViews";
 
 export enum CommandIDs {
   componenetVersionCreate = "ocm.component-version.create",
@@ -29,6 +29,7 @@ export enum CommandIDs {
   sourceOpen = "ocm.source.open",
   referenceOpen = "ocm.reference.open",
   remoteComponentAdd = "ocm.remote.add",
+  remoteComponentAddFromRegistry = "ocm.remote.addFromRegistry",
   remoteComponentRemove = "ocm.remote.remove",
   remoteTreeViewRefresh = "ocm.remote.refresh",
   workspaceTreeViewRefresh = "ocm.workspace.refresh",
@@ -54,6 +55,10 @@ export function registerCommands() {
   commands.registerCommand(CommandIDs.sourceOpen, openDocument);
   commands.registerCommand(CommandIDs.referenceOpen, openDocument);
   commands.registerCommand(CommandIDs.remoteComponentAdd, addRemoteComponent);
+  commands.registerCommand(
+    CommandIDs.remoteComponentAddFromRegistry,
+    addRemoteComponentFromRegistry
+  );
   commands.registerCommand(CommandIDs.remoteComponentRemove, removeRemoteComponent);
 
   commands.registerCommand(CommandIDs.remoteTreeViewRefresh, refreshRemoteTreeView);

--- a/src/commands/addRemoteComponent.ts
+++ b/src/commands/addRemoteComponent.ts
@@ -1,6 +1,11 @@
-import { getExtensionContext } from '../extensionContext';
-import { AddComponentPanel } from '../webviews/addComponent';
+import { getExtensionContext } from "../extensionContext";
+import { RegistryNode } from "../views/nodes/registryNode";
+import { AddComponentPanel } from "../webviews/addComponent";
 
 export async function addRemoteComponent() {
-	AddComponentPanel.createOrShow(getExtensionContext());
+  AddComponentPanel.createOrShow(getExtensionContext());
+}
+
+export async function addRemoteComponentFromRegistry(node: RegistryNode) {
+  AddComponentPanel.createOrShow(getExtensionContext(), node.name);
 }

--- a/src/commands/fetchComponents.ts
+++ b/src/commands/fetchComponents.ts
@@ -1,15 +1,37 @@
-import { shell } from '../shell';
-import { HttpsGardenerCloudSchemasComponentDescriptorOcmV3Alpha1 as ComponentDescriptorV3 } from '../ocm/ocmv3';
+import { HttpsGardenerCloudSchemasComponentDescriptorOcmV3Alpha1 as ComponentDescriptorV3 } from "../ocm/ocmv3";
+import { shell } from "../shell";
 
-export async function* fetchComponents(name: string): AsyncGenerator<ComponentDescriptorV3, any, void> {
-	const cmd = `ocm get components ${name} -ojson --scheme=v3alpha1`;
-	const result = await shell.exec(cmd);
-	if (result.code !== 0) {
-		return;
-	}
-	
-	const items = JSON.parse(result.stdout).items;
-	for (const i of items) {
-		yield i;
-	};
+export async function* fetchComponents(
+  name: string
+): AsyncGenerator<ComponentDescriptorV3, any, void> {
+  const cmd = `ocm get components ${name} -ojson --scheme=v3alpha1`;
+  const result = await shell.exec(cmd);
+  if (result.code !== 0) {
+    return;
+  }
+
+  const items = JSON.parse(result.stdout).items;
+  for (const i of items) {
+    yield i;
+  }
+}
+
+export interface FetchComponentsResult {
+  result: boolean;
+  error?: string;
+}
+
+export async function validateComponent(name: string): Promise<FetchComponentsResult> {
+  const cmd = `ocm get components ${name} -ojson --scheme=v3alpha1`;
+  const result = await shell.exec(cmd);
+  if (result.code !== 0) {
+    return {
+      result: false,
+      error: result.stderr,
+    };
+  }
+
+  return {
+    result: true,
+  };
 }

--- a/src/views/dataProviders/remoteDataProvider.ts
+++ b/src/views/dataProviders/remoteDataProvider.ts
@@ -1,27 +1,33 @@
-import { DataProvider } from './dataProvider';
-import { TreeNode } from '../nodes/treeNode';
-import { componentDescriptorParser, getComponentDescriptorMeta, ComponentMeta } from '../componentDescriptorToNode';
-import { GlobalState, GlobalStateKey } from '../../globalState';
-import { ComponentNode } from '../nodes/componentNode';
-import { ThemeIcon, window } from 'vscode';
-import { fetchComponents } from '../../commands/fetchComponents';
+import { fetchComponents } from "../../commands/fetchComponents";
+import { GlobalState, GlobalStateKey } from "../../globalState";
+import {
+  ComponentMeta,
+  componentDescriptorParser,
+  getComponentDescriptorMeta,
+} from "../componentDescriptorToNode";
+import { ComponentNode } from "../nodes/componentNode";
+import { RegistryNode } from "../nodes/registryNode";
+import { TreeNode } from "../nodes/treeNode";
+import { DataProvider } from "./dataProvider";
 
 export class RemoteDataProvider extends DataProvider {
   async buildTree(): Promise<TreeNode[]> {
-    let nodes: { [key: string]: TreeNode } = {};
+    let nodes: { [key: string]: RegistryNode } = {};
 
     let globalState = new GlobalState(this.context);
     let components: string[] | undefined = globalState.get(GlobalStateKey.Components);
 
-    if (!components) { return []; }
+    if (!components) {
+      return [];
+    }
 
     for (const name of components) {
       for await (const cd of fetchComponents(name)) {
         let meta: ComponentMeta = getComponentDescriptorMeta(cd);
-        
+
         if (!nodes.hasOwnProperty(meta.registry)) {
-          let regNode: TreeNode = new TreeNode(meta.registry);
-          regNode.setIcon(new ThemeIcon("database"));
+          let regNode: RegistryNode = new RegistryNode(meta.registry);
+
           nodes[meta.registry] = regNode;
         }
 
@@ -33,7 +39,7 @@ export class RemoteDataProvider extends DataProvider {
           }
         }
 
-        if (typeof n === 'undefined') {
+        if (typeof n === "undefined") {
           n = new ComponentNode(meta.name, meta.provider, meta.registry);
           nodes[meta.registry].addChild(n);
         }

--- a/src/views/nodes/registryNode.ts
+++ b/src/views/nodes/registryNode.ts
@@ -1,0 +1,23 @@
+import { ThemeIcon } from "vscode";
+import { TreeNode } from "./treeNode";
+
+export class RegistryNode extends TreeNode {
+  name: string;
+
+  constructor(name: string) {
+    super(name);
+
+    this.name = name;
+
+    this.iconPath = new ThemeIcon("database");
+  }
+
+  // @ts-ignore
+  get tooltip() {
+    return this.name;
+  }
+
+  get contexts() {
+    return ["Registry"];
+  }
+}


### PR DESCRIPTION
PR introduces 2 changes:

1. Add a context menu to the registry node in the remote component list, which automatically fills in the registry URL with the URL of the node selected.
2. Validate the component can is valid and can be downloaded before adding the component to the remote list.

![image](https://github.com/open-component-model/vscode-ocm-tools/assets/7720995/63a44dda-a78c-4bca-8605-b03ddcbe62c8)

![image](https://github.com/open-component-model/vscode-ocm-tools/assets/7720995/52be0e34-570a-4051-8ed6-14817a0171ba)
