### PR TITLE
introduce version field to add component view

### DIFF
--- a/media/addComponent/view.html
+++ b/media/addComponent/view.html
@@ -8,6 +8,9 @@
 	<div>
 		<label class="header-label" for="component">Component Name</label><input type="text" id="component">
 	</div>
+	<div>
+		<label class="header-label" for="version">Version</label><input type="text" id="version">
+	</div>
 </div>
 
 <button type="button" id="add-component" class="submit-button">Add</button>

--- a/media/addComponent/view.js
+++ b/media/addComponent/view.js
@@ -17,6 +17,7 @@ const webviewTempState = {
 // Generic cluster input ids
 const repositoryId = "repository";
 const componentId = "component";
+const versionId = "version";
 
 // Inputs
 const $repository = /** @type HTMLInputElement */ (document.getElementById(repositoryId));
@@ -30,6 +31,7 @@ $submitButton.addEventListener("click", () => {
       // @ts-ignore
       repositoryURL: getInputValue(repositoryId),
       componentName: getInputValue(componentId),
+      version: getInputValue(versionId),
     },
   });
 });

--- a/src/webviews/addComponent.ts
+++ b/src/webviews/addComponent.ts
@@ -28,6 +28,7 @@ export interface AddComponent {
   value: {
     repositoryURL: string;
     componentName: string;
+    version: string;
   };
 }
 
@@ -138,7 +139,10 @@ export class AddComponentPanel {
       async (message: MessageFromWebview) => {
         switch (message.type) {
           case "addComponent": {
-            const component = `${message.value.repositoryURL}/${message.value.componentName}`;
+            var component = `${message.value.repositoryURL}//${message.value.componentName}`;
+            if (message.value.version !== "") {
+              component = `${component}:${message.value.version}`;
+            }
             const result: FetchComponentsResult = await validateComponent(component);
             if (result.result === false && result.error !== undefined) {
               window.showErrorMessage(`Failed to add component: ${result.error}`);


### PR DESCRIPTION
Closes #38 

Adds an optional version field to the "Add Component" view. Versions can still be specified with with a `:` after the component name, this just adds an additional option.

![image](https://github.com/open-component-model/vscode-ocm-tools/assets/7720995/1173c690-0186-4f6a-85f7-5da46d8032d4)


![image](https://github.com/open-component-model/vscode-ocm-tools/assets/7720995/67ce2670-18fd-4fb6-98e2-6c1805b16965)
